### PR TITLE
fix build error

### DIFF
--- a/PerformanceMonitor/AppDelegate.m
+++ b/PerformanceMonitor/AppDelegate.m
@@ -17,7 +17,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
-    [[PerformanceMonitor sharedInstance] start];
+    [[PerformanceMonitor sharedInstance] startMonitor];
     
     return YES;
 }


### PR DESCRIPTION
`[[PerformanceMonitor sharedInstance] start]` => ` => [[PerformanceMonitor sharedInstance] startMonitor]`